### PR TITLE
use module.exports to export

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const normalizeMongoose = schema => {
+module.exports = schema => {
 	const {
 		toJSON,
 		normalizeId,
@@ -44,5 +44,3 @@ const normalizeMongoose = schema => {
 
 	schema.options.toJSON = {...toJSON, ...json};
 };
-
-export default normalizeMongoose;


### PR DESCRIPTION
hi, when I try to run my jest test case which use this module,
it show ```SyntaxError: Unexpected token 'export'```, since jest can't parse the es6 syntax in ```node_modules/```
Please update ```index.js``` to non-es6 version and update the npm module verison, thx : )

May be need to disable the ci check (```Error - Do not use "module". (unicorn/prefer-module)```) as well